### PR TITLE
Updated list of multicopters

### DIFF
--- a/data/performance/OpenAP/rotor/aircraft.json
+++ b/data/performance/OpenAP/rotor/aircraft.json
@@ -166,6 +166,23 @@
       "h_max": 2500,
       "d_range_max": 5      
    }
+  },
+  "W178": {
+    "name": "Wingcopter 178 Heavy Lift",
+    "n_engines": 4,
+    "engine_type": "TS",
+    "mtow": 18,
+    "oew": 12,
+    "mfc": 0,
+    "engines": [["SII-4035-560KV", 3.50], ["SII-4035-560KV", 3.50], ["SII-4035-560KV", 3.50], ["SII-4035-560KV", 3.50]],
+    "envelop": {
+      "v_min": -14,
+      "v_max": 41,
+      "vs_min": -5,
+      "vs_max": 6,
+      "h_max": 5000,
+      "d_range_max": 120
+    }
   }
 }  
       


### PR DESCRIPTION
Added Wingcopter 178 Heavy Lift
- Due to lack of official data, motor specifications have been inferred from [this](https://assets.publishing.service.gov.uk/media/5fd8ced2e90e071be641bfb3/Wingcopter_178_Heavylift_registration_na_01-21.pdf) incident report of a real use case, and similar motors from the same manufacturer [here](https://www.scorpionsystem.com/catalog/aeroplane/motors_1/sii-40/SII-4035-380/) and [here](https://www.scorpionsystem.com/catalog/aeroplane/motors_1/sii-40/SII-4035-450/).
- As the simulator does not support the switching of modes for a hybrid UAS, this includes the full capabilities of fixed wing mode as well.